### PR TITLE
Restricting the access to `package` - mind your architecture

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,14 @@
             <version>2.3.1</version>
         </dependency>
 
+		<!--AchUnit lib-->
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit4</artifactId>
+			<version>0.9.2</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/io/axoniq/demo/giftcard/command/GcCommandConfiguration.java
+++ b/src/main/java/io/axoniq/demo/giftcard/command/GcCommandConfiguration.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Profile("command")
-public class GcCommandConfiguration {
+class GcCommandConfiguration {
 
 	@Bean
 	public Repository<GiftCard> giftCardRepository(EventStore eventStore, Cache cache) {

--- a/src/main/java/io/axoniq/demo/giftcard/command/GiftCard.java
+++ b/src/main/java/io/axoniq/demo/giftcard/command/GiftCard.java
@@ -15,7 +15,7 @@ import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 
 @Aggregate
 @Profile("command")
-public class GiftCard {
+class GiftCard {
 
     private final static Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/src/main/java/io/axoniq/demo/giftcard/gui/BulkIssuer.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/BulkIssuer.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-public class BulkIssuer {
+class BulkIssuer {
 
     private final static Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/src/main/java/io/axoniq/demo/giftcard/gui/CardSummaryDataProvider.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/CardSummaryDataProvider.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
 
 @XSlf4j
 @RequiredArgsConstructor
-public class CardSummaryDataProvider extends AbstractBackEndDataProvider<CardSummary, Void> {
+class CardSummaryDataProvider extends AbstractBackEndDataProvider<CardSummary, Void> {
 
     private static final ExecutorService executorService = Executors.newCachedThreadPool();
 

--- a/src/main/java/io/axoniq/demo/giftcard/gui/GcGuiConfiguration.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/GcGuiConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Profile("gui")
-public class GcGuiConfiguration {
+class GcGuiConfiguration {
 
 	@EventListener(ApplicationReadyEvent.class)
 	public void helloHub(ApplicationReadyEvent event) {

--- a/src/main/java/io/axoniq/demo/giftcard/gui/GiftcardUI.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/GiftcardUI.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 @SpringUI
 @Push
 @Profile("gui")
-public class GiftcardUI extends UI {
+class GiftcardUI extends UI {
 
     private final static Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -64,7 +64,7 @@ public class GiftcardUI extends UI {
             public void error(com.vaadin.server.ErrorEvent event) {
                 Throwable cause = event.getThrowable();
                 log.error("an error occured", cause);
-                while(cause.getCause() != null) cause = cause.getCause();
+                while (cause.getCause() != null) cause = cause.getCause();
                 Notification.show("Error", cause.getMessage(), Notification.Type.ERROR_MESSAGE);
             }
         });
@@ -72,15 +72,15 @@ public class GiftcardUI extends UI {
         setPollInterval(1000);
         int offset = Page.getCurrent().getWebBrowser().getTimezoneOffset();
         // offset is in milliseconds
-             ZoneOffset instantOffset = ZoneOffset.ofTotalSeconds(offset/1000);
+        ZoneOffset instantOffset = ZoneOffset.ofTotalSeconds(offset / 1000);
         StatusUpdater statusUpdater = new StatusUpdater(statusLabel, instantOffset);
         updaterThread = Executors.newScheduledThreadPool(1).scheduleAtFixedRate(statusUpdater, 1000,
-                                                                     5000, TimeUnit.MILLISECONDS);
+                5000, TimeUnit.MILLISECONDS);
         setPollInterval(1000);
         getSession().getSession().setMaxInactiveInterval(30);
         addDetachListener((DetachListener) detachEvent -> {
-             log.warn("Closing UI");
-             updaterThread.cancel(true);
+            log.warn("Closing UI");
+            updaterThread.cancel(true);
 
         });
 
@@ -115,20 +115,20 @@ public class GiftcardUI extends UI {
         submit.addClickListener(evt -> {
             submit.setEnabled(false);
             new BulkIssuer(commandGateway, Integer.parseInt(number.getValue()), Integer.parseInt(amount.getValue()),
-                bulkIssuer -> {
-                    access(() -> {
-                        if(bulkIssuer.getRemaining().get() == 0) {
-                            submit.setEnabled(true);
-                            panel.setCaption("Bulk issue cards");
-                            Notification.show("Bulk issue card completed", Notification.Type.HUMANIZED_MESSAGE)
-                                    .addCloseListener(e -> cardSummaryDataProvider.refreshAll());
-                        } else {
-                            panel.setCaption(String.format("Progress: %d suc, %d fail, %d rem", bulkIssuer.getSuccess().get(),
-                                    bulkIssuer.getError().get(), bulkIssuer.getRemaining().get()));
-                            cardSummaryDataProvider.refreshAll();
-                        }
+                    bulkIssuer -> {
+                        access(() -> {
+                            if (bulkIssuer.getRemaining().get() == 0) {
+                                submit.setEnabled(true);
+                                panel.setCaption("Bulk issue cards");
+                                Notification.show("Bulk issue card completed", Notification.Type.HUMANIZED_MESSAGE)
+                                        .addCloseListener(e -> cardSummaryDataProvider.refreshAll());
+                            } else {
+                                panel.setCaption(String.format("Progress: %d suc, %d fail, %d rem", bulkIssuer.getSuccess().get(),
+                                        bulkIssuer.getError().get(), bulkIssuer.getRemaining().get()));
+                                cardSummaryDataProvider.refreshAll();
+                            }
+                        });
                     });
-                });
         });
 
         FormLayout form = new FormLayout();
@@ -170,24 +170,25 @@ public class GiftcardUI extends UI {
         return grid;
     }
 
-    public class StatusUpdater implements Runnable {
+    class StatusUpdater implements Runnable {
         private final Label statusLabel;
-         private final ZoneOffset instantOffset;
+        private final ZoneOffset instantOffset;
 
-         public StatusUpdater(Label statusLabel, ZoneOffset instantOffset) {
-             this.statusLabel = statusLabel;
-             this.instantOffset = instantOffset;
-         }
+        public StatusUpdater(Label statusLabel, ZoneOffset instantOffset) {
+            this.statusLabel = statusLabel;
+            this.instantOffset = instantOffset;
+        }
 
-         @Override
-         public void run() {
-             CountCardSummariesQuery query = new CountCardSummariesQuery();
-             queryGateway.query(
-                     query, CountCardSummariesResponse.class).whenComplete((r, exception) -> {
-                 if( exception == null) statusLabel.setValue(Instant.ofEpochMilli(r.getLastEvent()).atOffset(instantOffset).toString());
-             });
+        @Override
+        public void run() {
+            CountCardSummariesQuery query = new CountCardSummariesQuery();
+            queryGateway.query(
+                    query, CountCardSummariesResponse.class).whenComplete((r, exception) -> {
+                if (exception == null)
+                    statusLabel.setValue(Instant.ofEpochMilli(r.getLastEvent()).atOffset(instantOffset).toString());
+            });
 
-         }
+        }
 
     }
 }

--- a/src/main/java/io/axoniq/demo/giftcard/query/CardSummaryProjection.java
+++ b/src/main/java/io/axoniq/demo/giftcard/query/CardSummaryProjection.java
@@ -18,7 +18,7 @@ import java.util.List;
 @XSlf4j
 @RequiredArgsConstructor
 @Profile("query")
-public class CardSummaryProjection {
+class CardSummaryProjection {
 
     private final EntityManager entityManager;
     private final QueryUpdateEmitter queryUpdateEmitter;

--- a/src/test/java/io/axoniq/demo/giftcard/GcAppTest.java
+++ b/src/test/java/io/axoniq/demo/giftcard/GcAppTest.java
@@ -1,0 +1,23 @@
+package io.axoniq.demo.giftcard;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import org.junit.runner.RunWith;
+
+@RunWith(ArchUnitRunner.class)
+@AnalyzeClasses(packages = "io.axoniq.demo.giftcard")
+public class GcAppTest {
+
+    /**
+     * Testing if the classes in "..command.. , ..query.. " packages are package protected.
+     * <p>
+     * This will work with Java only. Kotlin does not have package modifier.
+     */
+    @ArchTest
+    public static final ArchRule encapsulationJavaRule = ArchRuleDefinition.classes()
+            .that().resideInAnyPackage("..command..", "..query..", "..gui..")
+            .should().bePackagePrivate();
+}


### PR DESCRIPTION
ArchUnit test included to check if the classes in `command`, `query` and `gui` packages are package private. Only classes in `api` package should be public. This enables loose coupling and high cohesion