### PR TITLE
Restricting the access to `package` - mind your architecture

### DIFF
--- a/src/main/java/io/axoniq/demo/giftcard/api/package-info.java
+++ b/src/main/java/io/axoniq/demo/giftcard/api/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API: Commands, Event and Queries
+ */
+package io.axoniq.demo.giftcard.api;

--- a/src/main/java/io/axoniq/demo/giftcard/command/GcCommandConfiguration.java
+++ b/src/main/java/io/axoniq/demo/giftcard/command/GcCommandConfiguration.java
@@ -14,14 +14,14 @@ import org.springframework.stereotype.Component;
 class GcCommandConfiguration {
 
 	@Bean
-	public Repository<GiftCard> giftCardRepository(EventStore eventStore, Cache cache) {
+	Repository<GiftCard> giftCardRepository(EventStore eventStore, Cache cache) {
 		return EventSourcingRepository.builder(GiftCard.class)
 				.cache(cache).eventStore(eventStore)
 				.build();
 	}
 
 	@Bean
-    public Cache cache() {
+	Cache cache() {
 	    return new WeakReferenceCache();
 	}
 }

--- a/src/main/java/io/axoniq/demo/giftcard/command/GiftCard.java
+++ b/src/main/java/io/axoniq/demo/giftcard/command/GiftCard.java
@@ -28,14 +28,14 @@ class GiftCard {
     }
 
     @CommandHandler
-    public GiftCard(IssueCmd cmd) {
+    GiftCard(IssueCmd cmd) {
         log.debug("handling {}", cmd);
         if(cmd.getAmount() <= 0) throw new IllegalArgumentException("amount <= 0");
         apply(new IssuedEvt(cmd.getId(), cmd.getAmount()));
     }
 
     @CommandHandler
-    public void handle(RedeemCmd cmd) {
+    void handle(RedeemCmd cmd) {
         log.debug("handling {}", cmd);
         if(cmd.getAmount() <= 0) throw new IllegalArgumentException("amount <= 0");
         if(cmd.getAmount() > remainingValue) throw new IllegalStateException("amount > remaining value");
@@ -43,13 +43,13 @@ class GiftCard {
     }
 
     @CommandHandler
-    public void handle(CancelCmd cmd) {
+    void handle(CancelCmd cmd) {
         log.debug("handling {}", cmd);
         apply(new CancelEvt(id));
     }
 
     @EventSourcingHandler
-    public void on(IssuedEvt evt) {
+    void on(IssuedEvt evt) {
         log.debug("applying {}", evt);
         id = evt.getId();
         remainingValue = evt.getAmount();
@@ -57,14 +57,14 @@ class GiftCard {
     }
 
     @EventSourcingHandler
-    public void on(RedeemedEvt evt) {
+    void on(RedeemedEvt evt) {
         log.debug("applying {}", evt);
         remainingValue -= evt.getAmount();
         log.debug("new remaining value: {}", remainingValue);
     }
 
     @EventSourcingHandler
-    public void on(CancelEvt evt) {
+    void on(CancelEvt evt) {
         log.debug("applying {}", evt);
         remainingValue = 0;
         log.debug("new remaining value: {}", remainingValue);

--- a/src/main/java/io/axoniq/demo/giftcard/command/package-info.java
+++ b/src/main/java/io/axoniq/demo/giftcard/command/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Command model: Aggregates, Sagas, External command handlers
+ */
+package io.axoniq.demo.giftcard.command;

--- a/src/main/java/io/axoniq/demo/giftcard/gui/BulkIssuer.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/BulkIssuer.java
@@ -1,7 +1,6 @@
 package io.axoniq.demo.giftcard.gui;
 
 import io.axoniq.demo.giftcard.api.IssueCmd;
-import com.vaadin.ui.UI;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +18,7 @@ class BulkIssuer {
     private final AtomicInteger error = new AtomicInteger();
     private final AtomicInteger remaining = new AtomicInteger();
 
-    public BulkIssuer(CommandGateway commandGateway, int number, int amount, Consumer<BulkIssuer> callback) {
+    BulkIssuer(CommandGateway commandGateway, int number, int amount, Consumer<BulkIssuer> callback) {
         remaining.set(number);
         new Thread(() -> {
             for(int i = 0; i < number; i++) {
@@ -50,15 +49,15 @@ class BulkIssuer {
         }).start();
     }
 
-    public AtomicInteger getSuccess() {
+    AtomicInteger getSuccess() {
         return success;
     }
 
-    public AtomicInteger getError() {
+    AtomicInteger getError() {
         return error;
     }
 
-    public AtomicInteger getRemaining() {
+    AtomicInteger getRemaining() {
         return remaining;
     }
 

--- a/src/main/java/io/axoniq/demo/giftcard/gui/GcGuiConfiguration.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/GcGuiConfiguration.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 class GcGuiConfiguration {
 
 	@EventListener(ApplicationReadyEvent.class)
-	public void helloHub(ApplicationReadyEvent event) {
+	void helloHub(ApplicationReadyEvent event) {
 		QueryGateway queryGateway = event.getApplicationContext().getBean(QueryGateway.class);
 		queryGateway.query(new CountCardSummariesQuery(),
 				ResponseTypes.instanceOf(CountCardSummariesResponse.class));

--- a/src/main/java/io/axoniq/demo/giftcard/gui/GiftcardUI.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/GiftcardUI.java
@@ -174,7 +174,7 @@ class GiftcardUI extends UI {
         private final Label statusLabel;
         private final ZoneOffset instantOffset;
 
-        public StatusUpdater(Label statusLabel, ZoneOffset instantOffset) {
+        StatusUpdater(Label statusLabel, ZoneOffset instantOffset) {
             this.statusLabel = statusLabel;
             this.instantOffset = instantOffset;
         }

--- a/src/main/java/io/axoniq/demo/giftcard/gui/package-info.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * GUI: Vaadin
+ */
+package io.axoniq.demo.giftcard.gui;

--- a/src/main/java/io/axoniq/demo/giftcard/query/CardSummaryProjection.java
+++ b/src/main/java/io/axoniq/demo/giftcard/query/CardSummaryProjection.java
@@ -24,7 +24,7 @@ class CardSummaryProjection {
     private final QueryUpdateEmitter queryUpdateEmitter;
 
     @EventHandler
-    public void on(IssuedEvt event) {
+    void on(IssuedEvt event) {
         log.trace("projecting {}", event);
         /*
          * Update our read model by inserting the new card. This is done so that upcoming regular
@@ -44,7 +44,7 @@ class CardSummaryProjection {
     }
 
     @EventHandler
-    public void on(RedeemedEvt event) {
+    void on(RedeemedEvt event) {
         log.trace("projecting {}", event);
         /*
          * Update our read model by updating the existing card. This is done so that upcoming regular
@@ -65,7 +65,7 @@ class CardSummaryProjection {
     }
 
     @QueryHandler
-    public List<CardSummary> handle(FetchCardSummariesQuery query) {
+    List<CardSummary> handle(FetchCardSummariesQuery query) {
         log.trace("handling {}", query);
         TypedQuery<CardSummary> jpaQuery = entityManager.createNamedQuery("CardSummary.fetch", CardSummary.class);
         jpaQuery.setParameter("idStartsWith", query.getFilter().getIdStartsWith());
@@ -75,7 +75,7 @@ class CardSummaryProjection {
     }
 
     @QueryHandler
-    public CountCardSummariesResponse handle(CountCardSummariesQuery query) {
+    CountCardSummariesResponse handle(CountCardSummariesQuery query) {
         log.trace("handling {}", query);
         TypedQuery<Long> jpaQuery = entityManager.createNamedQuery("CardSummary.count", Long.class);
         jpaQuery.setParameter("idStartsWith", query.getFilter().getIdStartsWith());

--- a/src/main/java/io/axoniq/demo/giftcard/query/package-info.java
+++ b/src/main/java/io/axoniq/demo/giftcard/query/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Query/Read model: Event handlers, Query handlers, Data projections
+ */
+package io.axoniq.demo.giftcard.query;

--- a/src/test/java/io/axoniq/demo/giftcard/ArchitectureTest.java
+++ b/src/test/java/io/axoniq/demo/giftcard/ArchitectureTest.java
@@ -8,11 +8,11 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import org.junit.runner.RunWith;
 
 @RunWith(ArchUnitRunner.class)
-@AnalyzeClasses(packages = "io.axoniq.demo.giftcard")
-public class GcAppTest {
+@AnalyzeClasses(packagesOf=ArchitectureTest.class)
+public class ArchitectureTest {
 
     /**
-     * Testing if the classes in "..command.. , ..query.. " packages are package protected.
+     * Testing if the classes in "..command.. , ..query.. ,..qui..  " packages are package protected.
      * <p>
      * This will work with Java only. Kotlin does not have package modifier.
      */


### PR DESCRIPTION
ArchUnit test included to check if the classes in `command`, `query` and `gui` packages are package private. Only classes in `api` package should be public. This enables loose coupling and high cohesion